### PR TITLE
fix(seed): insert auth.users shim before profiles to satisfy FK (CI e2e unblock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,45 @@ jobs:
         env:
           PGOPTIONS: -c app.e2e_seed_allowed=true
         run: psql "${{ steps.supabase-keys.outputs.db_url }}" -f e2e/fixtures/seed.sql
+      # Diagnostic: verify signInWithPassword works end-to-end against GoTrue
+      # BEFORE Playwright runs, so a GoTrue/auth error surfaces cleanly and
+      # isn't wrapped inside a Playwright failure. Fails the job early if auth
+      # is broken. TODO: remove once e2e is stable.
+      - name: Diagnostic — probe GoTrue signInWithPassword
+        env:
+          ANON_KEY: ${{ steps.supabase-keys.outputs.anon_key }}
+        run: |
+          set -o pipefail
+          echo "--- auth.users row for adminUser ---"
+          psql "${{ steps.supabase-keys.outputs.db_url }}" -c "select id, email, length(encrypted_password) as pw_len, email_confirmed_at, aud, role, raw_app_meta_data, raw_user_meta_data from auth.users where email='playwright-user-admin@test.local';"
+          echo
+          echo "--- auth.users column inventory ---"
+          psql "${{ steps.supabase-keys.outputs.db_url }}" -c "select column_name, data_type, is_nullable, column_default from information_schema.columns where table_schema='auth' and table_name='users' order by ordinal_position;"
+          echo
+          echo "--- curl /auth/v1/token?grant_type=password ---"
+          HTTP_CODE=$(curl -sS -o /tmp/gotrue.json -w '%{http_code}' \
+            -X POST 'http://localhost:54321/auth/v1/token?grant_type=password' \
+            -H "apikey: ${ANON_KEY}" \
+            -H "Authorization: Bearer ${ANON_KEY}" \
+            -H "Content-Type: application/json" \
+            -d '{"email":"playwright-user-admin@test.local","password":"playwright-fixture-only-do-not-use-in-prod"}')
+          echo "HTTP status: ${HTTP_CODE}"
+          echo "Response body (redacted tokens):"
+          jq 'del(.access_token, .refresh_token, .provider_token, .provider_refresh_token, .user.confirmation_token, .user.recovery_token)' /tmp/gotrue.json 2>/dev/null || cat /tmp/gotrue.json
+          echo
+          if [ "${HTTP_CODE}" = "200" ]; then
+            echo "OK — auth layer is healthy."
+          else
+            echo "FAIL — dumping GoTrue container logs:"
+            AUTH_CONTAINER=$(docker ps --filter name=supabase_auth --format '{{.Names}}' | head -1)
+            if [ -n "${AUTH_CONTAINER}" ]; then
+              docker logs --tail 200 "${AUTH_CONTAINER}" 2>&1 | tail -200
+            else
+              echo "(no supabase_auth container found)"
+              docker ps
+            fi
+            exit 1
+          fi
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Build app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,45 +130,6 @@ jobs:
         env:
           PGOPTIONS: -c app.e2e_seed_allowed=true
         run: psql "${{ steps.supabase-keys.outputs.db_url }}" -f e2e/fixtures/seed.sql
-      # Diagnostic: verify signInWithPassword works end-to-end against GoTrue
-      # BEFORE Playwright runs, so a GoTrue/auth error surfaces cleanly and
-      # isn't wrapped inside a Playwright failure. Fails the job early if auth
-      # is broken. TODO: remove once e2e is stable.
-      - name: Diagnostic — probe GoTrue signInWithPassword
-        env:
-          ANON_KEY: ${{ steps.supabase-keys.outputs.anon_key }}
-        run: |
-          set -o pipefail
-          echo "--- auth.users row for adminUser ---"
-          psql "${{ steps.supabase-keys.outputs.db_url }}" -c "select id, email, length(encrypted_password) as pw_len, email_confirmed_at, aud, role, raw_app_meta_data, raw_user_meta_data from auth.users where email='playwright-user-admin@test.local';"
-          echo
-          echo "--- auth.users column inventory ---"
-          psql "${{ steps.supabase-keys.outputs.db_url }}" -c "select column_name, data_type, is_nullable, column_default from information_schema.columns where table_schema='auth' and table_name='users' order by ordinal_position;"
-          echo
-          echo "--- curl /auth/v1/token?grant_type=password ---"
-          HTTP_CODE=$(curl -sS -o /tmp/gotrue.json -w '%{http_code}' \
-            -X POST 'http://localhost:54321/auth/v1/token?grant_type=password' \
-            -H "apikey: ${ANON_KEY}" \
-            -H "Authorization: Bearer ${ANON_KEY}" \
-            -H "Content-Type: application/json" \
-            -d '{"email":"playwright-user-admin@test.local","password":"playwright-fixture-only-do-not-use-in-prod"}')
-          echo "HTTP status: ${HTTP_CODE}"
-          echo "Response body (redacted tokens):"
-          jq 'del(.access_token, .refresh_token, .provider_token, .provider_refresh_token, .user.confirmation_token, .user.recovery_token)' /tmp/gotrue.json 2>/dev/null || cat /tmp/gotrue.json
-          echo
-          if [ "${HTTP_CODE}" = "200" ]; then
-            echo "OK — auth layer is healthy."
-          else
-            echo "FAIL — dumping GoTrue container logs:"
-            AUTH_CONTAINER=$(docker ps --filter name=supabase_auth --format '{{.Names}}' | head -1)
-            if [ -n "${AUTH_CONTAINER}" ]; then
-              docker logs --tail 200 "${AUTH_CONTAINER}" 2>&1 | tail -200
-            else
-              echo "(no supabase_auth container found)"
-              docker ps
-            fi
-            exit 1
-          fi
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Build app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,21 @@ jobs:
         run: supabase start
       - name: Wait for stack ready
         run: |
-          for i in {1..30}; do
-            if supabase status 2>/dev/null | grep -q 'API URL'; then
-              echo "Supabase ready after ${i} polls"
+          # Probe the REST endpoint directly rather than grepping `supabase status`.
+          # Older CLI versions printed "API URL"; newer ones print "Project URL"
+          # (seen in 2.92.1), which made the old grep pattern never match and
+          # caused this step to time out even when the stack was healthy.
+          # Hitting /rest/v1/ is the authoritative readiness check regardless
+          # of CLI label drift.
+          for i in {1..60}; do
+            if curl -sfI http://127.0.0.1:54321/rest/v1/ -o /dev/null; then
+              echo "Supabase REST ready after ${i} polls"
               exit 0
             fi
             sleep 2
           done
-          echo "Supabase did not become ready in 60s"
-          supabase status
+          echo "Supabase REST did not become ready in 120s"
+          supabase status || true
           exit 1
       # M5 — derive local keys from `supabase status --output json` instead
       # of storing them as GH secrets. These are deterministic fixed

--- a/e2e/fixtures/seed.sql
+++ b/e2e/fixtures/seed.sql
@@ -71,6 +71,17 @@ ON CONFLICT (id) DO NOTHING;
 --   adminUser     — is_admin + mfa + guild_member    (admin-create spec)
 --   no2faUser     — mfa_verified FALSE               (auth-errors 2fa variant)
 --   notInServer   — guild_member FALSE               (auth-errors not-in-server)
+--
+-- The auth.users INSERT above fired the `handle_new_user` trigger, which
+-- auto-created profile rows with is_admin/mfa_verified/guild_member all
+-- defaulting to FALSE (the trigger doesn't set mfa_verified or guild_member
+-- at all; is_admin is derived from admin_discord_ids which at trigger-time
+-- does not yet contain 100000000000000002). If we used ON CONFLICT DO NOTHING
+-- here, the trigger's FALSE defaults would stick and AdminGuard / mfa flows
+-- would refuse the fixture users. DO UPDATE ensures the seed's intended
+-- flags win — critical for admin-create and browse-respond specs.
+-- Idempotency preserved: re-applying the seed produces the same final row
+-- state regardless of how many times it runs.
 -- ------------------------------------------------------------
 INSERT INTO public.profiles (id, discord_id, discord_username, avatar_url, is_admin, mfa_verified, guild_member) VALUES
   ('11111111-1111-1111-1111-111111111111', '100000000000000001', 'PlaywrightMember',
@@ -81,7 +92,13 @@ INSERT INTO public.profiles (id, discord_id, discord_username, avatar_url, is_ad
    'https://cdn.discordapp.com/embed/avatars/0.png', false, false, true),
   ('44444444-4444-4444-4444-444444444444', '100000000000000004', 'PlaywrightNotMember',
    'https://cdn.discordapp.com/embed/avatars/0.png', false, true,  false)
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  discord_id = EXCLUDED.discord_id,
+  discord_username = EXCLUDED.discord_username,
+  avatar_url = EXCLUDED.avatar_url,
+  is_admin = EXCLUDED.is_admin,
+  mfa_verified = EXCLUDED.mfa_verified,
+  guild_member = EXCLUDED.guild_member;
 
 -- ------------------------------------------------------------
 -- admin_discord_ids — opt the admin fixture Discord ID into auto-admin on

--- a/e2e/fixtures/seed.sql
+++ b/e2e/fixtures/seed.sql
@@ -32,22 +32,37 @@ END $$;
 -- `crypt()` + `gen_salt('bf')` are provided by pgcrypto, which Supabase
 -- enables by default.
 -- ------------------------------------------------------------
+-- GoTrue v2.188+ (bundled with Supabase CLI 2.92.1) cannot scan NULL values
+-- for confirmation_token, recovery_token, email_change_token_new, email_change
+-- because its User struct declares them as `string` (not `sql.NullString`).
+-- The auth.users schema leaves these columns nullable without a default, so
+-- any row we hand-insert that omits them makes EVERY signInWithPassword call
+-- fail with "error finding user: sql: Scan error ... converting NULL to
+-- string is unsupported" — the SELECT scans ALL rows matching the email,
+-- and any NULL in these columns tanks the whole query.
+-- Empty strings match the semantics GoTrue uses for its own internal inserts.
 INSERT INTO auth.users (
   id, instance_id, aud, role, email, encrypted_password,
-  email_confirmed_at, raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+  email_confirmed_at, raw_app_meta_data, raw_user_meta_data,
+  confirmation_token, recovery_token, email_change_token_new, email_change,
+  created_at, updated_at
 ) VALUES
   ('11111111-1111-1111-1111-111111111111', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
    'playwright-user-member@test.local', crypt('playwright-fixture-only-do-not-use-in-prod', gen_salt('bf')),
-   now(), '{"provider":"email"}', '{"provider_id":"100000000000000001"}', now(), now()),
+   now(), '{"provider":"email"}', '{"provider_id":"100000000000000001"}',
+   '', '', '', '', now(), now()),
   ('22222222-2222-2222-2222-222222222222', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
    'playwright-user-admin@test.local', crypt('playwright-fixture-only-do-not-use-in-prod', gen_salt('bf')),
-   now(), '{"provider":"email"}', '{"provider_id":"100000000000000002"}', now(), now()),
+   now(), '{"provider":"email"}', '{"provider_id":"100000000000000002"}',
+   '', '', '', '', now(), now()),
   ('33333333-3333-3333-3333-333333333333', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
    'playwright-user-no2fa@test.local', crypt('playwright-fixture-only-do-not-use-in-prod', gen_salt('bf')),
-   now(), '{"provider":"email"}', '{"provider_id":"100000000000000003"}', now(), now()),
+   now(), '{"provider":"email"}', '{"provider_id":"100000000000000003"}',
+   '', '', '', '', now(), now()),
   ('44444444-4444-4444-4444-444444444444', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
    'playwright-user-notmember@test.local', crypt('playwright-fixture-only-do-not-use-in-prod', gen_salt('bf')),
-   now(), '{"provider":"email"}', '{"provider_id":"100000000000000004"}', now(), now())
+   now(), '{"provider":"email"}', '{"provider_id":"100000000000000004"}',
+   '', '', '', '', now(), now())
 ON CONFLICT (id) DO NOTHING;
 
 -- ------------------------------------------------------------

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -43,16 +43,16 @@ ON CONFLICT (id) DO NOTHING;
 -- scans multiple rows when emails collide. See e2e/fixtures/seed.sql for
 -- the same fix and the full explanation.
 INSERT INTO auth.users (
-  id, instance_id, aud, role, email,
+  id, instance_id, aud, role, email, email_confirmed_at,
   raw_app_meta_data, raw_user_meta_data,
   confirmation_token, recovery_token, email_change_token_new, email_change,
   created_at, updated_at
 ) VALUES
   ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
-   'seed-admin-1@local', '{"provider":"discord"}', '{"provider_id":"111111111111111111","full_name":"WTCS_Admin","avatar_url":"https://cdn.discordapp.com/embed/avatars/0.png"}',
+   'seed-admin-1@local', now(), '{"provider":"discord"}', '{"provider_id":"111111111111111111","full_name":"WTCS_Admin","avatar_url":"https://cdn.discordapp.com/embed/avatars/0.png"}',
    '', '', '', '', now(), now()),
   ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
-   'seed-admin-2@local', '{"provider":"discord"}', '{"provider_id":"222222222222222222","full_name":"MapCommittee","avatar_url":"https://cdn.discordapp.com/embed/avatars/1.png"}',
+   'seed-admin-2@local', now(), '{"provider":"discord"}', '{"provider_id":"222222222222222222","full_name":"MapCommittee","avatar_url":"https://cdn.discordapp.com/embed/avatars/1.png"}',
    '', '', '', '', now(), now())
 ON CONFLICT (id) DO NOTHING;
 
@@ -67,15 +67,21 @@ ON CONFLICT (id) DO NOTHING;
 -- the seeded is_admin=true and mfa_verified=true — critical because
 -- the trigger uses GREATEST(existing, new), so true sticks after.
 -- ============================================================
-INSERT INTO public.profiles (id, discord_id, discord_username, avatar_url, is_admin, mfa_verified) VALUES
-  ('00000000-0000-0000-0000-000000000001', '111111111111111111', 'WTCS_Admin', 'https://cdn.discordapp.com/embed/avatars/0.png', true, true),
-  ('00000000-0000-0000-0000-000000000002', '222222222222222222', 'MapCommittee', 'https://cdn.discordapp.com/embed/avatars/1.png', true, true)
+-- guild_member = true is required: public.is_current_user_admin() checks
+-- is_admin AND mfa_verified AND guild_member (see migration 00000000000009).
+-- Omitting it would leave seeded admins with guild_member=false (the column
+-- default), causing every admin-gated RLS policy and RPC to reject them.
+INSERT INTO public.profiles (id, discord_id, discord_username, avatar_url, is_admin, mfa_verified, guild_member) VALUES
+  ('00000000-0000-0000-0000-000000000001', '111111111111111111', 'WTCS_Admin', 'https://cdn.discordapp.com/embed/avatars/0.png', true, true, true),
+  ('00000000-0000-0000-0000-000000000002', '222222222222222222', 'MapCommittee', 'https://cdn.discordapp.com/embed/avatars/1.png', true, true, true)
 ON CONFLICT (id) DO UPDATE SET
   discord_id = EXCLUDED.discord_id,
   discord_username = EXCLUDED.discord_username,
   avatar_url = EXCLUDED.avatar_url,
   is_admin = EXCLUDED.is_admin,
-  mfa_verified = EXCLUDED.mfa_verified;
+  mfa_verified = EXCLUDED.mfa_verified,
+  guild_member = EXCLUDED.guild_member,
+  updated_at = now();
 
 -- ============================================================
 -- Seed Data: Suggestions (D-33)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -35,14 +35,25 @@ ON CONFLICT (id) DO NOTHING;
 -- since these accounts never log in — they only exist to satisfy the FK and
 -- act as `created_by` targets for seed polls).
 -- ============================================================
+-- Empty strings (not NULL) for confirmation_token / recovery_token /
+-- email_change_token_new / email_change: GoTrue v2.188+ scans these as
+-- Go `string` and errors with "converting NULL to string is unsupported"
+-- if any row in auth.users has NULL in these columns — even for rows
+-- unrelated to the current sign-in, because GoTrue's user-lookup SELECT
+-- scans multiple rows when emails collide. See e2e/fixtures/seed.sql for
+-- the same fix and the full explanation.
 INSERT INTO auth.users (
   id, instance_id, aud, role, email,
-  raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+  raw_app_meta_data, raw_user_meta_data,
+  confirmation_token, recovery_token, email_change_token_new, email_change,
+  created_at, updated_at
 ) VALUES
   ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
-   'seed-admin-1@local', '{"provider":"discord"}', '{"provider_id":"111111111111111111","full_name":"WTCS_Admin","avatar_url":"https://cdn.discordapp.com/embed/avatars/0.png"}', now(), now()),
+   'seed-admin-1@local', '{"provider":"discord"}', '{"provider_id":"111111111111111111","full_name":"WTCS_Admin","avatar_url":"https://cdn.discordapp.com/embed/avatars/0.png"}',
+   '', '', '', '', now(), now()),
   ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
-   'seed-admin-2@local', '{"provider":"discord"}', '{"provider_id":"222222222222222222","full_name":"MapCommittee","avatar_url":"https://cdn.discordapp.com/embed/avatars/1.png"}', now(), now())
+   'seed-admin-2@local', '{"provider":"discord"}', '{"provider_id":"222222222222222222","full_name":"MapCommittee","avatar_url":"https://cdn.discordapp.com/embed/avatars/1.png"}',
+   '', '', '', '', now(), now())
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -26,15 +26,45 @@ INSERT INTO public.categories (id, name, slug, sort_order) VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================
+-- Seed Data: auth.users shim rows for local dev only.
+-- public.profiles.id has FK → auth.users.id, so we must create the auth rows
+-- before inserting profiles. supabase/seed.sql runs ONLY on `supabase start`
+-- and `supabase db reset` against the local Docker stack — never against
+-- hosted Supabase projects — so these fixture auth users are safe here.
+-- Mirrors the pattern used in e2e/fixtures/seed.sql (minus the bcrypt password,
+-- since these accounts never log in — they only exist to satisfy the FK and
+-- act as `created_by` targets for seed polls).
+-- ============================================================
+INSERT INTO auth.users (
+  id, instance_id, aud, role, email,
+  raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+) VALUES
+  ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+   'seed-admin-1@local', '{"provider":"discord"}', '{"provider_id":"111111111111111111","full_name":"WTCS_Admin","avatar_url":"https://cdn.discordapp.com/embed/avatars/0.png"}', now(), now()),
+  ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+   'seed-admin-2@local', '{"provider":"discord"}', '{"provider_id":"222222222222222222","full_name":"MapCommittee","avatar_url":"https://cdn.discordapp.com/embed/avatars/1.png"}', now(), now())
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
 -- Seed Data: Profiles (poll creators)
--- Note: These reference auth.users via FK. In local dev with Supabase CLI,
--- you may need to insert matching auth.users rows first or disable FK checks.
--- For seeding purposes these use deterministic UUIDs.
+-- The auth.users INSERT above triggers handle_new_user (from
+-- migration 00000000000002_triggers.sql), which auto-creates profile
+-- rows with is_admin derived from admin_discord_ids. Since the
+-- admin_discord_ids entries above are placeholder strings (not
+-- matching the seeded provider_ids), the trigger produces profiles
+-- with is_admin=false. We use ON CONFLICT DO UPDATE below to force
+-- the seeded is_admin=true and mfa_verified=true — critical because
+-- the trigger uses GREATEST(existing, new), so true sticks after.
 -- ============================================================
 INSERT INTO public.profiles (id, discord_id, discord_username, avatar_url, is_admin, mfa_verified) VALUES
   ('00000000-0000-0000-0000-000000000001', '111111111111111111', 'WTCS_Admin', 'https://cdn.discordapp.com/embed/avatars/0.png', true, true),
   ('00000000-0000-0000-0000-000000000002', '222222222222222222', 'MapCommittee', 'https://cdn.discordapp.com/embed/avatars/1.png', true, true)
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  discord_id = EXCLUDED.discord_id,
+  discord_username = EXCLUDED.discord_username,
+  avatar_url = EXCLUDED.avatar_url,
+  is_admin = EXCLUDED.is_admin,
+  mfa_verified = EXCLUDED.mfa_verified;
 
 -- ============================================================
 -- Seed Data: Suggestions (D-33)


### PR DESCRIPTION
## Summary

**Restores CI green for lint-and-unit on main, and gets the e2e job all the way from "fails at `supabase start`" to "runs the full Playwright suite."** Five infrastructure fixes in a single PR:

1. `2271bf1` — **supabase/seed.sql**: INSERT `auth.users` shim rows before `public.profiles` (the existing seed violated the `profiles_id_fkey` FK). First-ever cold-start seed.
2. `3c17734` — **.github/workflows/ci.yml "Wait for stack ready"**: probe REST endpoint directly with `curl` instead of grepping `supabase status` for `API URL` (CLI 2.92.1 renamed that column to `Project URL`, so the old grep never matched and the step timed out at 60s even when the stack was healthy).
3. `2727664` — **supabase/seed.sql + e2e/fixtures/seed.sql**: set `''` defaults for `confirmation_token` / `recovery_token` / `email_change_token_new` / `email_change`. GoTrue v2.188.1 (bundled with CLI 2.92.1) declares these as Go `string`, not `sql.NullString`, so it errors with `"sql: Scan error … converting NULL to string is unsupported"` on every `signInWithPassword` against any auth.users row that has NULL in these columns.
4. `8b0cd81` — **e2e/fixtures/seed.sql**: `ON CONFLICT DO UPDATE` (not DO NOTHING) on `public.profiles`. The `handle_new_user` trigger auto-creates profile rows during the preceding `auth.users` INSERT with `is_admin=false` / `mfa_verified=false` / `guild_member=false`; `DO NOTHING` made those false values stick, so fixture users were silently non-admin / non-verified. Safe to change because the protection trigger has a `WHEN (current_setting('role') = 'authenticated')` clause — psql-as-postgres bypasses it.
5. `c32e958` — removed temporary GoTrue diagnostic step (used to surface root cause #3).

## Verification

Diagnostic probe (commit `015e9b1`, reverted by `c32e958`) captured this after the fix chain:

```
HTTP status: 200
{
  "token_type": "bearer",
  "user": { "id": "22222222-2222-2222-2222-222222222222", ... "email_confirmed_at": "2026-04-24T07:15:52.044864Z" },
  ...
}
OK — auth layer is healthy.
```

## What this PR does NOT fix

The e2e job still fails — but now at the **Playwright test layer**, not the infra layer. The 3 failing smoke tests have pre-existing test-authoring bugs that were never exposed before because CI never got this far. Tracking each separately:

- **#11** — `admin-create.spec.ts`: test fills only Title before submit; `SuggestionForm` validates Choice 1/2 non-empty → submit blocked → URL assertion times out.
- **#12** — `browse-respond.spec.ts`: asserts `\d+ total response` count, but `e2e/fixtures/seed.sql` seeds no votes so the text never renders.
- **#13** — `filter-search.spec.ts`: `toHaveCount()` ignores that CI runs two seed layers (`supabase/seed.sql` + `e2e/fixtures/seed.sql`).

## Impact of not merging vs merging

- **Not merging**: CI stays where it is today — `lint-and-unit` passes (already on main via `e421455`), `e2e` fails at `supabase start` with FK violation. All dependabot PRs also red for the same reasons.
- **Merging**: `e2e` fails later in the pipeline, at real test logic, with real diagnostic value (Playwright reports upload). Each subsequent test fix is small and reviewable.

Merging is strictly better. Each of #11 / #12 / #13 becomes a focused ~5-line PR.

## Test plan

- [x] `lint-and-unit` passes on this PR (already green — unchanged from main).
- [x] `supabase start` completes (FK fix verified).
- [x] REST readiness probe finds the stack within the poll window.
- [x] `curl /auth/v1/token?grant_type=password` returns 200 (auth layer healthy).
- [x] `psql` shows `is_admin=true` / `mfa_verified=true` / `guild_member=true` on the fixture admin user after both seeds apply.
- [ ] (Optional — separate PRs) Fix each of #11 / #12 / #13 so the full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened database seeding logic to ensure consistent and reliable initialization of user accounts and role permissions during application startup and test environments
  * Enhanced continuous integration pipeline reliability with improved Supabase service readiness verification using direct endpoint testing
  * Refined end-to-end test fixtures to properly maintain and refresh user privilege assignments and authentication data on test re-seed operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->