### PR TITLE
fix(15): address PR #35 reviewer comments (Gemini + Greptile)

### DIFF
--- a/.planning/phases/15-observability-e2e-verify-close/15-01-SUMMARY.md
+++ b/.planning/phases/15-observability-e2e-verify-close/15-01-SUMMARY.md
@@ -3,6 +3,8 @@ plan: 15-01
 phase: 15-observability-e2e-verify-close
 status: complete
 commit: 79acd86
+tasks_completed: 2
+tasks_total: 2
 ---
 
 # 15-01 Summary

--- a/.planning/phases/15-observability-e2e-verify-close/15-02-SUMMARY.md
+++ b/.planning/phases/15-observability-e2e-verify-close/15-02-SUMMARY.md
@@ -2,6 +2,8 @@
 plan: 15-02
 phase: 15-observability-e2e-verify-close
 status: complete
+tasks_completed: 2
+tasks_total: 2
 ---
 
 # 15-02 Summary — verify-sourcemap-names.mjs

--- a/.planning/phases/15-observability-e2e-verify-close/15-03-SUMMARY.md
+++ b/.planning/phases/15-observability-e2e-verify-close/15-03-SUMMARY.md
@@ -3,6 +3,8 @@ plan: 15-03
 phase: 15-observability-e2e-verify-close
 status: complete
 commit: 684797e
+tasks_completed: 1
+tasks_total: 1
 ---
 
 ## Objective

--- a/.planning/phases/15-observability-e2e-verify-close/15-04-SUMMARY.md
+++ b/.planning/phases/15-observability-e2e-verify-close/15-04-SUMMARY.md
@@ -2,6 +2,8 @@
 phase: 15-observability-e2e-verify-close
 plan: 04
 status: complete
+tasks_completed: 5
+tasks_total: 5
 requirements: [OBSV-03, OBSV-04, OBSV-05, TEST-14, TEST-15, TEST-16]
 ---
 

--- a/.planning/phases/15-observability-e2e-verify-close/15-05-SUMMARY.md
+++ b/.planning/phases/15-observability-e2e-verify-close/15-05-SUMMARY.md
@@ -2,6 +2,8 @@
 phase: 15-observability-e2e-verify-close
 plan: 05
 status: complete
+tasks_completed: 4
+tasks_total: 4
 requirements: [OBSV-03, OBSV-04, OBSV-05, TEST-14, TEST-15, TEST-16]
 ---
 

--- a/scripts/verify-sourcemap-names.mjs
+++ b/scripts/verify-sourcemap-names.mjs
@@ -63,7 +63,7 @@ const missing = ALLOWLIST.filter((name) => {
 
 if (missing.length > 0) {
   console.error(
-    `[verify-sourcemap-names] FAIL: ${missing.length} name(s) missing from dist/assets/*.js\n` +
+    `[verify-sourcemap-names] FAIL: ${missing.length} name(s) missing from dist/assets/**/*.js\n` +
     missing.map((n) => `  - ${n}`).join('\n') + '\n' +
     'This means vite.config.ts rolldownOptions.output.keepNames may have regressed. ' +
     'Restore the flag or update the allowlist if a name was renamed in source.'

--- a/scripts/verify-sourcemap-names.mjs
+++ b/scripts/verify-sourcemap-names.mjs
@@ -44,7 +44,10 @@ try {
   process.exit(1);
 }
 
-const entries = await readdir(DIST_ASSETS);
+// `recursive: true` walks nested subdirs (e.g. `dist/assets/vendor/*.js`) so a
+// future Rollup/Vite chunking change can't silently shrink coverage to top-level
+// chunks only. Returns paths relative to DIST_ASSETS.
+const entries = await readdir(DIST_ASSETS, { recursive: true });
 const jsFiles = entries.filter((e) => e.endsWith('.js'));
 
 const contents = await Promise.all(

--- a/src/routes/[__smoke].tsx
+++ b/src/routes/[__smoke].tsx
@@ -11,7 +11,7 @@ interface SmokeSearch {
 }
 
 const RenderThrowSmoke = lazy(() =>
-  import('../components/debug/RenderThrowSmoke').then(m => ({
+  import('@/components/debug/RenderThrowSmoke').then(m => ({
     default: m.RenderThrowSmoke,
   }))
 )


### PR DESCRIPTION
## Summary

Follow-up to the merged Phase 15 PR ([#35](https://github.com/Esk3tit/wtcs-community-polls/pull/35)). Six P-medium reviewer comments from gemini-code-assist and greptile-apps landed on PR #35 but were not addressed before merge — this PR addresses all of them.

The Phase 15 merge was a process failure on the orchestrator side (`/gsd-execute-phase 15`): CI went green, the orchestrator marked the draft ready and merged within ~1 minute, leaving zero window for bot reviews to complete. CodeRabbit's review actually FAILED on that PR (not noticed), and Gemini + Greptile's comments were captured but ignored. A merge-gate memory rule has been added (`feedback_pr_merge_gate.md`) so this doesn't recur.

## Changes

| Fix | File | Reviewer | Severity | Type |
|---|---|---|---|---|
| Revert `../components/debug/RenderThrowSmoke` → `@/components/debug/RenderThrowSmoke` for project alias consistency | `src/routes/[__smoke].tsx` | Gemini #1 + Greptile #5 | P-medium / P2 | Style |
| `readdir(DIST_ASSETS)` → `readdir(DIST_ASSETS, { recursive: true })` so subdirectory chunks (e.g. `dist/assets/vendor/`) can't silently shrink coverage and report false OK | `scripts/verify-sourcemap-names.mjs` | Greptile #6 | P2 | **Real bug** |
| Backfill `tasks_completed` / `tasks_total` frontmatter metrics (required by planning template) | `15-01`/`15-02`/`15-03-SUMMARY.md` | Gemini #2/#3/#4 | P-medium | Process / metadata |
| Add same frontmatter metrics for consistency (predated Gemini's review window) | `15-04`/`15-05-SUMMARY.md` | — | — | Consistency |

## Validation

- `npm run build` — passes (no chunk-size or warning regression vs Phase 15 baseline)
- `node scripts/verify-sourcemap-names.mjs` — `OK: 38 chunk(s) scanned, 7/7 allowlisted names found — keepNames contract holds.` (exit 0)
- `npx eslint src/routes/[__smoke].tsx` — clean
- Worktree dependencies of the alias change: none — `@/` alias is configured in both `vite.config.ts` (line 38-39) and `tsconfig.app.json` (`paths: { "@/*": ["./src/*"] }`) and used everywhere else in src/

## Test plan

- [x] CI `lint-and-unit` job passes (includes the new recursive-readdir verify step)
- [x] CI `e2e` job passes (smoke route behavior unchanged — same dynamic import target, just different path syntax)
- [x] All 3 configured bot reviews complete: CodeRabbit + Gemini + Greptile
- [x] User explicit merge approval per the new `feedback_pr_merge_gate.md` rule

## Notes

- Phase 15 is already shipped on `main` (PR #35 merged commit `2b75412`); this PR does NOT reopen any closed issues.
- The `tasks_completed`/`tasks_total` backfill in 15-04 and 15-05 SUMMARY frontmatters was not flagged by Gemini (it reviewed only the pre-Wave-4 state), but added here for uniform metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project phase completion tracking across observability verification phases.
  * Enhanced sourcemap name verification to include nested asset paths in regression checks.
  * Refactored import paths to use path aliases for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Esk3tit/wtcs-community-polls/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->