### PR TITLE
Phase 17: admin list shadcn Card migration (UIDN-04/05)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ A community suggestion and opinion-gathering platform for the War Thunder Compet
 - Local imports grouped: contexts → hooks → components → utilities → types
 - CSS imports last (or only in `main.tsx` for `index.css`)
 ### Path Aliases
-- Not configured — relative imports used throughout `src/`
+- `@/*` → `./src/*` — the dominant convention (~117 of 153 `src/` files); configured in `tsconfig.app.json` (`paths`), `vite.config.ts` (`resolve.alias`), and `components.json` (shadcn aliases). Prefer `@/` over relative imports for cross-directory references; a handful of same-directory relative imports remain.
 - Module resolution: `bundler` mode via `tsconfig.app.json`
 ### Module Syntax
 - ESM only (`"type": "module"` in `package.json`)

--- a/src/__tests__/admin/admins-tab.test.tsx
+++ b/src/__tests__/admin/admins-tab.test.tsx
@@ -114,9 +114,18 @@ describe('AdminsList', () => {
     await waitFor(() => expect(screen.getByText('Khai')).toBeInTheDocument())
     const promoteBtn = screen.getByRole('button', { name: /promote admin/i })
     fireEvent.click(promoteBtn)
-    // Dialog title is also "Promote admin"
-    const matches = screen.getAllByText(/promote admin/i)
-    expect(matches.length).toBeGreaterThanOrEqual(1)
+    // Radix DialogContent applies role="dialog" + aria-labelledby at runtime from
+    // the DialogTitle wrapper — verify the Card migration preserves it.
+    expect(await screen.findByRole('dialog', { name: /promote admin/i })).toBeInTheDocument()
+  })
+
+  it('exposes the Admins section title as a level-2 heading', async () => {
+    render(<AdminsList />)
+    // CardTitle renders a plain <div>; role="heading" + aria-level keep the
+    // section reachable by screen-reader heading navigation after the Card migration.
+    expect(
+      await screen.findByRole('heading', { level: 2, name: 'Admins' }),
+    ).toBeInTheDocument()
   })
 })
 

--- a/src/__tests__/admin/categories-tab.test.tsx
+++ b/src/__tests__/admin/categories-tab.test.tsx
@@ -99,6 +99,15 @@ describe('CategoriesList', () => {
       screen.getByPlaceholderText('New category name'),
     ).toBeInTheDocument()
   })
+
+  it('exposes the Categories section title as a level-2 heading', async () => {
+    render(<CategoriesList />)
+    // CardTitle renders a plain <div>; role="heading" + aria-level keep the
+    // section reachable by screen-reader heading navigation after the Card migration.
+    expect(
+      await screen.findByRole('heading', { level: 2, name: 'Categories' }),
+    ).toBeInTheDocument()
+  })
 })
 
 describe('CategoriesList error state (MEDIUM #7)', () => {

--- a/src/components/admin/AdminsList.tsx
+++ b/src/components/admin/AdminsList.tsx
@@ -2,6 +2,13 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { UserMinus, AlertCircle, UserPlus, Users } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardAction,
+  CardContent,
+} from '@/components/ui/card'
 import { useAuth } from '@/hooks/useAuth'
 import { supabase } from '@/lib/supabase'
 import { deferSetState } from '@/lib/deferSetState'
@@ -78,39 +85,45 @@ export function AdminsList() {
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold">Admins</h2>
-        <Button onClick={() => setPromoteOpen(true)} size="sm" className="h-9">
-          <UserPlus className="h-4 w-4 mr-1" />
-          Promote admin
-        </Button>
-      </div>
+    // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
+    // keeps its pre-migration row density inside the bordered container.
+    <Card className="py-0">
+      <CardHeader>
+        <CardTitle role="heading" aria-level={2} className="text-base">
+          Admins
+        </CardTitle>
+        <CardAction>
+          <Button onClick={() => setPromoteOpen(true)} size="sm" className="h-9">
+            <UserPlus className="h-4 w-4 mr-1" />
+            Promote admin
+          </Button>
+        </CardAction>
+      </CardHeader>
 
-      {loading ? (
-        <div className="divide-y border rounded-md">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-[64px] bg-muted/30 animate-pulse"
-              data-testid="admin-skeleton"
-            />
-          ))}
-        </div>
-      ) : (
-        <div className={admins.length === 0 ? '' : 'divide-y border rounded-md'}>
-          {admins.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-16 text-center">
-              <Users className="h-10 w-10 text-muted-foreground" />
-              <p className="text-lg font-medium text-foreground mt-4">
-                No admins yet.
-              </p>
-              <p className="text-sm text-muted-foreground mt-1">
-                Promote one to get started.
-              </p>
-            </div>
-          ) : (
-            admins.map((a) => {
+      <CardContent className="p-0">
+        {loading ? (
+          <div className="divide-y">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-[64px] bg-muted/30 animate-pulse"
+                data-testid="admin-skeleton"
+              />
+            ))}
+          </div>
+        ) : admins.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Users className="h-10 w-10 text-muted-foreground" />
+            <p className="text-lg font-medium text-foreground mt-4">
+              No admins yet.
+            </p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Promote one to get started.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {admins.map((a) => {
               // Hide Demote on the acting admin's own row (UI guard against self-demotion).
               const isSelf = user?.id === a.id
               return (
@@ -156,10 +169,10 @@ export function AdminsList() {
                   )}
                 </div>
               )
-            })
-          )}
-        </div>
-      )}
+            })}
+          </div>
+        )}
+      </CardContent>
 
       <PromoteAdminDialog
         open={promoteOpen}
@@ -182,6 +195,6 @@ export function AdminsList() {
           }}
         />
       )}
-    </div>
+    </Card>
   )
 }

--- a/src/components/admin/AdminsList.tsx
+++ b/src/components/admin/AdminsList.tsx
@@ -87,7 +87,9 @@ export function AdminsList() {
   return (
     // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
     // keeps its pre-migration row density inside the bordered container.
-    <Card className="py-0">
+    // overflow-hidden clips the flush square-cornered rows/skeletons to the
+    // Card's rounded corners so they don't bleed past the bottom radius.
+    <Card className="py-0 overflow-hidden">
       <CardHeader>
         <CardTitle role="heading" aria-level={2} className="text-base">
           Admins

--- a/src/components/admin/CategoriesList.tsx
+++ b/src/components/admin/CategoriesList.tsx
@@ -19,6 +19,13 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardAction,
+  CardContent,
+} from '@/components/ui/card'
 import { supabase } from '@/lib/supabase'
 import { useCategories } from '@/hooks/useCategories'
 import { useCategoryMutations } from '@/hooks/useCategoryMutations'
@@ -155,157 +162,165 @@ export function CategoriesList() {
     !loading && !error && categories.length === 0 && !newRowActive
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold">Categories</h2>
-        <Button
-          size="sm"
-          className="h-9"
-          onClick={handleStartNew}
-          disabled={newRowActive || submitting}
-        >
-          <Plus className="h-4 w-4 mr-1" />
-          New category
-        </Button>
-      </div>
-
-      {loading ? (
-        <div className="divide-y">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-[56px] bg-muted/30 animate-pulse"
-              data-testid="category-skeleton"
-            />
-          ))}
-        </div>
-      ) : showEmpty ? (
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          <Folder className="h-10 w-10 text-muted-foreground mb-3" />
-          <p className="text-lg font-medium text-foreground mt-4">
-            No categories yet.
-          </p>
-          <p className="text-sm text-muted-foreground mt-1">
-            Create one to organize suggestions.
-          </p>
-          <Button className="mt-4" size="sm" onClick={handleStartNew}>
+    // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
+    // keeps its pre-migration row density inside the bordered container.
+    <Card className="py-0">
+      <CardHeader>
+        <CardTitle role="heading" aria-level={2} className="text-base">
+          Categories
+        </CardTitle>
+        <CardAction>
+          <Button
+            size="sm"
+            className="h-9"
+            onClick={handleStartNew}
+            disabled={newRowActive || submitting}
+          >
             <Plus className="h-4 w-4 mr-1" />
             New category
           </Button>
-        </div>
-      ) : (
-        <div className="divide-y border rounded-md">
-          {newRowActive && (
-            <div className="flex items-center justify-between p-4 min-h-[56px] gap-3">
-              <Input
-                ref={newInputRef}
-                value={newRowValue}
-                onChange={(e) => setNewRowValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') void handleSaveNew()
-                  if (e.key === 'Escape') handleCancelNew()
-                }}
-                placeholder="New category name"
-                className="h-9 text-sm"
-              />
-              <div className="flex items-center gap-1">
-                <Button
-                  size="icon"
-                  variant="default"
-                  className="h-9 w-9"
-                  aria-label="Save new category"
-                  onClick={() => void handleSaveNew()}
-                  disabled={submitting}
-                >
-                  <Check className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-9 w-9"
-                  aria-label="Cancel new category"
-                  onClick={handleCancelNew}
-                  disabled={submitting}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          )}
-          {categories.map((cat) => {
-            const isEditing = editingId === cat.id
-            return (
+        </CardAction>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {loading ? (
+          <div className="divide-y">
+            {Array.from({ length: 4 }).map((_, i) => (
               <div
-                key={cat.id}
-                className="flex items-center justify-between p-4 min-h-[56px] gap-3"
-              >
-                {isEditing ? (
-                  <>
-                    <Input
-                      ref={editInputRef}
-                      value={editValue}
-                      onChange={(e) => setEditValue(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') void handleSaveEdit(cat.id)
-                        if (e.key === 'Escape') handleCancelEdit()
-                      }}
-                      className="h-9 text-sm"
-                    />
-                    <div className="flex items-center gap-1">
-                      <Button
-                        size="icon"
-                        variant="default"
-                        className="h-9 w-9"
-                        aria-label={`Save ${cat.name}`}
-                        onClick={() => void handleSaveEdit(cat.id)}
-                        disabled={submitting}
-                      >
-                        <Check className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-9 w-9"
-                        aria-label={`Cancel ${cat.name}`}
-                        onClick={handleCancelEdit}
-                        disabled={submitting}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <span className="text-sm font-medium">{cat.name}</span>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-9 w-9"
-                        aria-label={`Edit category ${cat.name}`}
-                        disabled={submitting}
-                        onClick={() => handleStartEdit(cat)}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-9 w-9 text-destructive hover:text-destructive"
-                        aria-label={`Delete category ${cat.name}`}
-                        disabled={submitting}
-                        onClick={() => void handleAskDelete(cat)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </>
-                )}
+                key={i}
+                className="h-[56px] bg-muted/30 animate-pulse"
+                data-testid="category-skeleton"
+              />
+            ))}
+          </div>
+        ) : showEmpty ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Folder className="h-10 w-10 text-muted-foreground mb-3" />
+            <p className="text-lg font-medium text-foreground mt-4">
+              No categories yet.
+            </p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Create one to organize suggestions.
+            </p>
+            <Button className="mt-4" size="sm" onClick={handleStartNew}>
+              <Plus className="h-4 w-4 mr-1" />
+              New category
+            </Button>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {newRowActive && (
+              <div className="flex items-center justify-between p-4 min-h-[56px] gap-3">
+                <Input
+                  ref={newInputRef}
+                  value={newRowValue}
+                  onChange={(e) => setNewRowValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void handleSaveNew()
+                    if (e.key === 'Escape') handleCancelNew()
+                  }}
+                  placeholder="New category name"
+                  className="h-9 text-sm"
+                />
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="icon"
+                    variant="default"
+                    className="h-9 w-9"
+                    aria-label="Save new category"
+                    onClick={() => void handleSaveNew()}
+                    disabled={submitting}
+                  >
+                    <Check className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-9 w-9"
+                    aria-label="Cancel new category"
+                    onClick={handleCancelNew}
+                    disabled={submitting}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
-            )
-          })}
-        </div>
-      )}
+            )}
+            {categories.map((cat) => {
+              const isEditing = editingId === cat.id
+              return (
+                <div
+                  key={cat.id}
+                  className="flex items-center justify-between p-4 min-h-[56px] gap-3"
+                >
+                  {isEditing ? (
+                    <>
+                      <Input
+                        ref={editInputRef}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') void handleSaveEdit(cat.id)
+                          if (e.key === 'Escape') handleCancelEdit()
+                        }}
+                        className="h-9 text-sm"
+                      />
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="icon"
+                          variant="default"
+                          className="h-9 w-9"
+                          aria-label={`Save edit for ${cat.name}`}
+                          onClick={() => void handleSaveEdit(cat.id)}
+                          disabled={submitting}
+                        >
+                          <Check className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-9 w-9"
+                          aria-label={`Cancel edit for ${cat.name}`}
+                          onClick={handleCancelEdit}
+                          disabled={submitting}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <span className="text-sm font-medium">{cat.name}</span>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-9 w-9"
+                          aria-label={`Edit category ${cat.name}`}
+                          disabled={submitting}
+                          onClick={() => handleStartEdit(cat)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-9 w-9 text-destructive hover:text-destructive"
+                          aria-label={`Delete category ${cat.name}`}
+                          disabled={submitting}
+                          onClick={() => void handleAskDelete(cat)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
 
       <Dialog
         open={!!deleteTarget}
@@ -342,6 +357,6 @@ export function CategoriesList() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </Card>
   )
 }

--- a/src/components/admin/CategoriesList.tsx
+++ b/src/components/admin/CategoriesList.tsx
@@ -164,7 +164,9 @@ export function CategoriesList() {
   return (
     // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
     // keeps its pre-migration row density inside the bordered container.
-    <Card className="py-0">
+    // overflow-hidden clips the flush square-cornered rows/skeletons to the
+    // Card's rounded corners so they don't bleed past the bottom radius.
+    <Card className="py-0 overflow-hidden">
       <CardHeader>
         <CardTitle role="heading" aria-level={2} className="text-base">
           Categories

--- a/src/components/admin/PromoteAdminDialog.tsx
+++ b/src/components/admin/PromoteAdminDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Card, CardContent } from '@/components/ui/card'
 import { useSearchAdminTargets } from '@/hooks/useSearchAdminTargets'
 import { usePromoteAdmin } from '@/hooks/usePromoteAdmin'
 
@@ -85,39 +86,43 @@ export function PromoteAdminDialog({ open, onOpenChange, onPromoted }: Props) {
             />
           </div>
           {results.length > 0 && (
-            <div className="mt-2 border rounded-md divide-y max-h-64 overflow-auto">
-              {results.slice(0, 10).map((r) => (
-                <div
-                  key={r.id}
-                  className="flex items-center gap-2 p-2 hover:bg-accent rounded-md min-h-[44px]"
-                >
-                  {r.avatar_url ? (
-                    <img
-                      src={r.avatar_url}
-                      alt=""
-                      className="h-6 w-6 rounded-full"
-                    />
-                  ) : (
-                    <div className="h-6 w-6 rounded-full bg-muted" />
-                  )}
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">
-                      {r.discord_username}
-                    </p>
-                    <p className="text-xs text-muted-foreground font-mono truncate">
-                      {r.discord_id}
-                    </p>
-                  </div>
-                  <Button
-                    size="sm"
-                    onClick={() => void handlePromoteTarget(r.id)}
-                    disabled={submitting}
-                  >
-                    Promote
-                  </Button>
+            <Card className="mt-2 max-h-64 overflow-auto py-0">
+              <CardContent className="p-0">
+                <div className="divide-y">
+                  {results.slice(0, 10).map((r) => (
+                    <div
+                      key={r.id}
+                      className="flex items-center gap-2 p-2 hover:bg-accent min-h-[44px]"
+                    >
+                      {r.avatar_url ? (
+                        <img
+                          src={r.avatar_url}
+                          alt=""
+                          className="h-6 w-6 rounded-full"
+                        />
+                      ) : (
+                        <div className="h-6 w-6 rounded-full bg-muted" />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">
+                          {r.discord_username}
+                        </p>
+                        <p className="text-xs text-muted-foreground font-mono truncate">
+                          {r.discord_id}
+                        </p>
+                      </div>
+                      <Button
+                        size="sm"
+                        onClick={() => void handlePromoteTarget(r.id)}
+                        disabled={submitting}
+                      >
+                        Promote
+                      </Button>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
+              </CardContent>
+            </Card>
           )}
           {showNoMatches && (
             <p className="text-xs text-muted-foreground mt-2">


### PR DESCRIPTION
## Summary

**Phase 17: Planning-doc + UI hygiene sweep** (milestone v1.3 — Hygiene & Performance)
**Status:** Verified ✓ (7/7 phase must-haves)

The code half of phase 17 — requirements **UIDN-04 / UIDN-05**. Replaces the hand-rolled `<div className="… border rounded-md">` list containers in the three admin components with the vendored shadcn `Card` primitive, matching the native-Card look already used by `LandingPage` / `AuthErrorPage`. The change is structural-only: no behavior, props, event handlers, or copy changed.

> The phase also had a markdown-only planning-doc reconciliation half (DOCS-05/06/07/08). Those `.planning/` changes are intentionally excluded from this PR so reviewers see only the code surface.

## Changes

### Admin Card migration (UIDN-04)
- **`AdminsList.tsx`** / **`CategoriesList.tsx`** — `Card` + `CardHeader`/`CardTitle`/`CardAction`/`CardContent` replace the hand-rolled flex headers and bordered containers. `py-0` / `p-0` overrides cancel shadcn Card's default padding so the lists keep their pre-migration row density.

### Promote dialog (UIDN-05)
- **`PromoteAdminDialog.tsx`** — search-results container → `Card` / `CardContent`; the Radix `DialogContent` / `DialogTitle` wrappers are untouched so runtime ARIA (`role="dialog"` + `aria-labelledby`) is preserved.

### Accessibility
- shadcn `CardTitle` renders a plain `<div>`, which would have demoted the "Admins" / "Categories" section `<h2>`s. Restored heading semantics with `role="heading" aria-level={2}` so the admin page outline (`<h1>Admin</h1>` → two `<h2>` sections) survives.
- Edit-row save/cancel `aria-label`s clarified (`Save edit for …` / `Cancel edit for …`).

### Tests
- **`admins-tab.test.tsx`** — strengthened the promote-dialog assertion to `findByRole('dialog', { name: /promote admin/i })`; added an `Admins` level-2 heading regression test.
- **`categories-tab.test.tsx`** — added the symmetric `Categories` level-2 heading regression test.

### Docs
- **`CLAUDE.md`** — corrected the path-alias convention note (`@/` is configured, not relative-only).

## Requirements Addressed

- **UIDN-04** — `AdminsList` / `CategoriesList` hand-rolled containers → shadcn `Card`
- **UIDN-05** — `PromoteAdminDialog` search-results container → shadcn `Card`

## Verification

- [x] Phase verification: **7/7** must-haves (`.planning/phases/17-…/VERIFICATION.md` → `status: passed`)
- [x] Build: `npm run build` exit 0
- [x] Lint: `eslint .` exit 0 · Types: `tsc -b` exit 0
- [x] Tests: **403/403** passing (43 files), including the new dialog-ARIA and heading regression tests
- [x] Deep code review: converged at 0 critical / 0 warning / 3 info (cosmetic, accepted) — `17-REVIEW.md`
- [x] UI audit: 23/24 (`17-UI-REVIEW.md`)

## Key Decisions

- **D-01** Native shadcn `Card` styling — no pixel-parity overrides beyond padding cancellation.
- **D-09** Plan B is a code-only, file-disjoint slice from the planning-doc half (parallel-safe).
- Structural-only contract: behavioral test surface (handlers, refs, state, snowflake validation) verified unchanged against the pre-migration diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added path aliases configuration guide in project documentation.

* **Tests**
  * Enhanced accessibility testing for admin dialogs and headings with proper ARIA attributes.
  * Added verification for section title heading levels in admin interface.

* **Refactor**
  * Standardized admin interface component layout structure for improved consistency.
  * Refined admin list and categories UI component organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->