### PR TITLE
Phase 19: DB Migration + A11y Restore (DBHY-05 + UIDN-06)

### DIFF
--- a/e2e/integration/profile-trigger-gate.test.ts
+++ b/e2e/integration/profile-trigger-gate.test.ts
@@ -1,0 +1,153 @@
+// DBHY-05 regression test — profile_self_update_allowed trigger gate.
+//
+// Proves the GUC-based gate works in both directions:
+//   - Direct authenticated client UPDATEs to protected columns are rejected.
+//   - The update_profile_after_auth RPC bypasses the gate (GUC is set inside
+//     the RPC before the UPDATE, so the trigger takes the trusted path).
+//   - The transaction-local GUC does not leak across HTTP requests / pooled
+//     connections (GUC-leak guard, case f).
+//
+// This test is RED before supabase db push applies Migration 15 — the prior
+// migration's gate was permanently false in SECURITY DEFINER context, so
+// direct UPDATEs to protected columns were silently accepted. Full green
+// requires Plan 03 (supabase db push).
+//
+// Why beforeEach (not beforeAll) for the reset: each case mutates or attempts
+// to mutate the memberUser profile. A per-case reset guarantees the starting
+// state is known regardless of execution order (is_admin=false after case b
+// would otherwise bleed into case e's precondition).
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { mintClients, type IntegrationClients } from './helpers'
+import { fixtureUsers } from '../fixtures/test-users'
+
+describe('profile_self_update_allowed trigger gate (DBHY-05)', () => {
+  let clients: IntegrationClients
+
+  beforeAll(async () => {
+    clients = await mintClients({ authAs: 'memberUser' })
+  })
+
+  // Re-baseline memberUser before every case so cases are order-independent.
+  // serviceRole writes succeed on the GUC-gated path because the trigger's
+  // protected-column branch only enforces against the authenticated direct-client
+  // path — serviceRole bypasses RLS entirely, so it operates as the function
+  // owner context where the GUC check does not apply.
+  beforeEach(async () => {
+    await clients.serviceRole
+      .from('profiles')
+      .update({
+        is_admin: false,
+        mfa_verified: true,
+        guild_member: true,
+        discord_username: 'PlaywrightMember',
+      })
+      .eq('id', fixtureUsers.memberUser.id)
+  })
+
+  afterAll(async () => {
+    // Restore fixture profile to seed state so sibling suites see expected values.
+    // is_admin:false is explicitly restored because case (b) attempted is_admin:true
+    // and prior Migration 14 (broken gate) would have silently accepted it.
+    await clients.serviceRole
+      .from('profiles')
+      .update({ is_admin: false, mfa_verified: true, guild_member: true })
+      .eq('id', fixtureUsers.memberUser.id)
+  })
+
+  it('(a) direct authenticated UPDATE to mfa_verified is rejected by trigger', async () => {
+    const { error } = await clients.authed
+      .from('profiles')
+      .update({ mfa_verified: false })
+      .eq('id', fixtureUsers.memberUser.id)
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/mfa_verified via client/i)
+  })
+
+  it('(b) direct authenticated UPDATE to is_admin is rejected by trigger', async () => {
+    const { error } = await clients.authed
+      .from('profiles')
+      .update({ is_admin: true })
+      .eq('id', fixtureUsers.memberUser.id)
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/is_admin via client/i)
+  })
+
+  it('(c) direct authenticated UPDATE to guild_member is rejected by trigger', async () => {
+    const { error } = await clients.authed
+      .from('profiles')
+      .update({ guild_member: false })
+      .eq('id', fixtureUsers.memberUser.id)
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/guild_member via client/i)
+  })
+
+  it('(d) direct authenticated UPDATE to discord_username is allowed (non-protected column)', async () => {
+    const { error } = await clients.authed
+      .from('profiles')
+      .update({ discord_username: 'RenamedMember' })
+      .eq('id', fixtureUsers.memberUser.id)
+    // Proves the gate does NOT block non-protected columns when the GUC is absent.
+    // Guards against over-broad enforcement in the trigger.
+    expect(error).toBeNull()
+  })
+
+  it('(e) update_profile_after_auth RPC succeeds via GUC bypass — ordered proof', async () => {
+    // Step 1: Flip protected columns to a known-different state via serviceRole.
+    // This ensures the subsequent RPC assertion cannot pass as a no-op write.
+    await clients.serviceRole
+      .from('profiles')
+      .update({ mfa_verified: false, guild_member: false })
+      .eq('id', fixtureUsers.memberUser.id)
+
+    // Step 2: Read back and assert the flip actually applied (precondition holds).
+    const { data: pre } = await clients.serviceRole
+      .from('profiles')
+      .select('mfa_verified, guild_member')
+      .eq('id', fixtureUsers.memberUser.id)
+      .single()
+    expect(pre!.mfa_verified).toBe(false)
+    expect(pre!.guild_member).toBe(false)
+
+    // Step 3: Call the RPC via the authed client — must succeed.
+    const { error } = await clients.authed.rpc('update_profile_after_auth', {
+      p_mfa_verified: true,
+      p_discord_username: 'PlaywrightMember',
+      p_avatar_url: 'https://cdn.discordapp.com/embed/avatars/0.png',
+      p_guild_member: true,
+    })
+    expect(error).toBeNull()
+
+    // Step 4: Read back via serviceRole and assert protected columns were committed.
+    // A no-op write (member already true) cannot satisfy this because step 1 set them false.
+    const { data: post } = await clients.serviceRole
+      .from('profiles')
+      .select('mfa_verified, guild_member')
+      .eq('id', fixtureUsers.memberUser.id)
+      .single()
+    expect(post!.mfa_verified).toBe(true)
+    expect(post!.guild_member).toBe(true)
+  })
+
+  it('(f) GUC-leak guard: transaction-local GUC does not persist after RPC completes', async () => {
+    // First ensure the RPC path works (sets up the GUC internally, then commits,
+    // which auto-clears the transaction-local flag).
+    await clients.authed.rpc('update_profile_after_auth', {
+      p_mfa_verified: true,
+      p_discord_username: 'PlaywrightMember',
+      p_avatar_url: 'https://cdn.discordapp.com/embed/avatars/0.png',
+      p_guild_member: true,
+    })
+
+    // Immediately after the RPC completes, attempt a direct UPDATE on the same
+    // authed client. The GUC was set inside the RPC's transaction — it must have
+    // auto-cleared on commit (is_local=true). The next request must be rejected,
+    // proving the GUC did not leak across HTTP requests or pooled connections.
+    const { error: leak } = await clients.authed
+      .from('profiles')
+      .update({ mfa_verified: false })
+      .eq('id', fixtureUsers.memberUser.id)
+    expect(leak).not.toBeNull()
+    expect(leak!.message).toMatch(/mfa_verified via client/i)
+  })
+})

--- a/e2e/integration/profile-trigger-gate.test.ts
+++ b/e2e/integration/profile-trigger-gate.test.ts
@@ -29,10 +29,10 @@ describe('profile_self_update_allowed trigger gate (DBHY-05)', () => {
   })
 
   // Re-baseline memberUser before every case so cases are order-independent.
-  // serviceRole writes succeed on the GUC-gated path because the trigger's
-  // protected-column branch only enforces against the authenticated direct-client
-  // path — serviceRole bypasses RLS entirely, so it operates as the function
-  // owner context where the GUC check does not apply.
+  // serviceRole writes skip the trigger because on_profile_self_update is
+  // declared WHEN (current_setting('role') = 'authenticated'); a service_role
+  // connection has role='service_role', so the trigger body (and its GUC gate)
+  // never executes. This is a trigger-WHEN bypass, NOT an RLS bypass.
   beforeEach(async () => {
     await clients.serviceRole
       .from('profiles')

--- a/src/__tests__/admin/admins-tab.test.tsx
+++ b/src/__tests__/admin/admins-tab.test.tsx
@@ -121,8 +121,7 @@ describe('AdminsList', () => {
 
   it('exposes the Admins section title as a level-2 heading', async () => {
     render(<AdminsList />)
-    // CardTitle renders a plain <div>; role="heading" + aria-level keep the
-    // section reachable by screen-reader heading navigation after the Card migration.
+    // CardTitle asChild renders a native <h2> — no ARIA override needed.
     expect(
       await screen.findByRole('heading', { level: 2, name: 'Admins' }),
     ).toBeInTheDocument()

--- a/src/__tests__/admin/categories-tab.test.tsx
+++ b/src/__tests__/admin/categories-tab.test.tsx
@@ -102,8 +102,7 @@ describe('CategoriesList', () => {
 
   it('exposes the Categories section title as a level-2 heading', async () => {
     render(<CategoriesList />)
-    // CardTitle renders a plain <div>; role="heading" + aria-level keep the
-    // section reachable by screen-reader heading navigation after the Card migration.
+    // CardTitle asChild renders a native <h2> — no ARIA override needed.
     expect(
       await screen.findByRole('heading', { level: 2, name: 'Categories' }),
     ).toBeInTheDocument()

--- a/src/components/admin/AdminsList.tsx
+++ b/src/components/admin/AdminsList.tsx
@@ -91,8 +91,8 @@ export function AdminsList() {
     // Card's rounded corners so they don't bleed past the bottom radius.
     <Card className="py-0 overflow-hidden">
       <CardHeader>
-        <CardTitle role="heading" aria-level={2} className="text-base">
-          Admins
+        <CardTitle asChild className="text-base">
+          <h2>Admins</h2>
         </CardTitle>
         <CardAction>
           <Button onClick={() => setPromoteOpen(true)} size="sm" className="h-9">

--- a/src/components/admin/AdminsList.tsx
+++ b/src/components/admin/AdminsList.tsx
@@ -86,7 +86,7 @@ export function AdminsList() {
 
   return (
     // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
-    // keeps its pre-migration row density inside the bordered container.
+    // keeps its compact row density inside the bordered container.
     // overflow-hidden clips the flush square-cornered rows/skeletons to the
     // Card's rounded corners so they don't bleed past the bottom radius.
     <Card className="py-0 overflow-hidden">

--- a/src/components/admin/AdminsList.tsx
+++ b/src/components/admin/AdminsList.tsx
@@ -86,11 +86,13 @@ export function AdminsList() {
 
   return (
     // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
-    // keeps its compact row density inside the bordered container.
+    // keeps its compact row density inside the bordered container; the
+    // CardHeader re-adds its own pt-4 pb-3 so the section title still has
+    // breathing room above it and a gap before the first row.
     // overflow-hidden clips the flush square-cornered rows/skeletons to the
     // Card's rounded corners so they don't bleed past the bottom radius.
     <Card className="py-0 overflow-hidden">
-      <CardHeader>
+      <CardHeader className="pt-4 pb-3">
         <CardTitle asChild className="text-base">
           <h2>Admins</h2>
         </CardTitle>

--- a/src/components/admin/CategoriesList.tsx
+++ b/src/components/admin/CategoriesList.tsx
@@ -163,7 +163,7 @@ export function CategoriesList() {
 
   return (
     // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
-    // keeps its pre-migration row density inside the bordered container.
+    // keeps its compact row density inside the bordered container.
     // overflow-hidden clips the flush square-cornered rows/skeletons to the
     // Card's rounded corners so they don't bleed past the bottom radius.
     <Card className="py-0 overflow-hidden">

--- a/src/components/admin/CategoriesList.tsx
+++ b/src/components/admin/CategoriesList.tsx
@@ -163,11 +163,13 @@ export function CategoriesList() {
 
   return (
     // py-0 / p-0 cancel shadcn Card's default vertical padding so the list
-    // keeps its compact row density inside the bordered container.
+    // keeps its compact row density inside the bordered container; the
+    // CardHeader re-adds its own pt-4 pb-3 so the section title still has
+    // breathing room above it and a gap before the first row.
     // overflow-hidden clips the flush square-cornered rows/skeletons to the
     // Card's rounded corners so they don't bleed past the bottom radius.
     <Card className="py-0 overflow-hidden">
-      <CardHeader>
+      <CardHeader className="pt-4 pb-3">
         <CardTitle asChild className="text-base">
           <h2>Categories</h2>
         </CardTitle>

--- a/src/components/admin/CategoriesList.tsx
+++ b/src/components/admin/CategoriesList.tsx
@@ -168,8 +168,8 @@ export function CategoriesList() {
     // Card's rounded corners so they don't bleed past the bottom radius.
     <Card className="py-0 overflow-hidden">
       <CardHeader>
-        <CardTitle role="heading" aria-level={2} className="text-base">
-          Categories
+        <CardTitle asChild className="text-base">
+          <h2>Categories</h2>
         </CardTitle>
         <CardAction>
           <Button

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -28,9 +29,14 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div"
   return (
-    <div
+    <Comp
       data-slot="card-title"
       className={cn("leading-none font-semibold", className)}
       {...props}

--- a/supabase/migrations/00000000000015_trusted_profile_update_guc.sql
+++ b/supabase/migrations/00000000000015_trusted_profile_update_guc.sql
@@ -1,0 +1,127 @@
+-- Replaces the permanently-false caller-identity gate in
+-- profile_self_update_allowed with a transaction-local GUC flag
+-- (app.trusted_profile_update) set by update_profile_after_auth.
+--
+-- DBHY-05: inside a SECURITY DEFINER trigger, current_user always resolves to
+-- the function owner, never to the session role — the prior identity check was
+-- always false, so direct client UPDATEs to is_admin, mfa_verified, and
+-- guild_member were silently accepted. This migration makes the gate functional.
+--
+-- GUC built-ins are pg_catalog-qualified (pg_catalog.set_config,
+-- pg_catalog.current_setting) because search_path is pinned to empty string
+-- on these functions — an unqualified built-in would fail to resolve at call time.
+--
+-- Gate predicate uses IS DISTINCT FROM 'on' (null-safe three-valued-logic-safe),
+-- matching the in-repo precedent at e2e/fixtures/seed.sql (app.e2e_seed_allowed
+-- IS DISTINCT FROM 'true').
+--
+-- Migration also makes the update_profile_after_auth EXECUTE grant explicit:
+-- REVOKE ... FROM PUBLIC + GRANT ... TO authenticated, so the trusted boundary
+-- is auditable rather than relying on the Postgres default PUBLIC EXECUTE.
+
+
+-- update_profile_after_auth — sets the transaction-local GUC before UPDATE
+-- so profile_self_update_allowed sees the trusted-context flag within the
+-- same transaction.
+CREATE OR REPLACE FUNCTION public.update_profile_after_auth(
+  p_mfa_verified BOOLEAN,
+  p_discord_username TEXT,
+  p_avatar_url TEXT,
+  p_guild_member BOOLEAN DEFAULT FALSE
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- Mark this transaction as trusted so profile_self_update_allowed
+  -- skips protected-column checks. is_local=true (third arg) scopes the
+  -- GUC to this transaction only — auto-clears on commit/rollback, safe
+  -- under PgBouncer transaction pooling.
+  PERFORM pg_catalog.set_config('app.trusted_profile_update', 'on', true);
+
+  UPDATE public.profiles
+  SET
+    mfa_verified = p_mfa_verified,
+    discord_username = p_discord_username,
+    avatar_url = p_avatar_url,
+    guild_member = p_guild_member,
+    updated_at = NOW()
+  WHERE id = auth.uid();
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Profile not found for current user';
+  END IF;
+END;
+$$;
+
+
+-- profile_self_update_allowed — replaces the permanently-false identity gate
+-- with the GUC check. The flag is set by update_profile_after_auth before
+-- its UPDATE; direct client UPDATEs do not set it, so the flag is absent
+-- and protected-column checks run (IS DISTINCT FROM 'on' fires).
+CREATE OR REPLACE FUNCTION public.profile_self_update_allowed()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- Always enforce immutable columns regardless of caller
+  IF NEW.id != OLD.id THEN
+    RAISE EXCEPTION 'Cannot change profile id';
+  END IF;
+  IF NEW.discord_id != OLD.discord_id THEN
+    RAISE EXCEPTION 'Cannot change discord_id';
+  END IF;
+  IF NEW.created_at != OLD.created_at THEN
+    RAISE EXCEPTION 'Cannot change created_at';
+  END IF;
+
+  -- Check trusted-context flag set by update_profile_after_auth.
+  -- missing_ok=true (second arg) returns '' when the GUC is absent
+  -- (direct client path) instead of raising. IS DISTINCT FROM 'on' is
+  -- null-safe; gate fires (protected checks run) when the flag is absent.
+  IF pg_catalog.current_setting('app.trusted_profile_update', true) IS DISTINCT FROM 'on' THEN
+    -- Direct client update — enforce protected column restrictions
+    IF NEW.is_admin != OLD.is_admin THEN
+      RAISE EXCEPTION 'Cannot change is_admin via client';
+    END IF;
+    IF NEW.mfa_verified != OLD.mfa_verified THEN
+      RAISE EXCEPTION 'Cannot change mfa_verified via client -- use update_profile_after_auth RPC';
+    END IF;
+    IF NEW.guild_member != OLD.guild_member THEN
+      RAISE EXCEPTION 'Cannot change guild_member via client -- use update_profile_after_auth RPC';
+    END IF;
+  END IF;
+
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+
+COMMENT ON FUNCTION public.profile_self_update_allowed IS
+  'Guards profile self-update: blocks id/discord_id/created_at unconditionally; '
+  'blocks is_admin/mfa_verified/guild_member when app.trusted_profile_update GUC is absent '
+  '(direct client write). update_profile_after_auth sets the GUC (transaction-local, '
+  'is_local=true) before its UPDATE so the protected-column checks are skipped on the '
+  'RPC path. IS DISTINCT FROM ''on'' is used for null-safe gate evaluation.';
+
+COMMENT ON FUNCTION public.update_profile_after_auth(BOOLEAN, TEXT, TEXT, BOOLEAN) IS
+  'SECURITY DEFINER RPC: sets the transaction-local GUC app.trusted_profile_update '
+  'before updating the caller''s own profile row (auth.uid()). This makes it the sole '
+  'sanctioned writer for mfa_verified and guild_member. TRUST BOUNDARY: trusts '
+  'caller-supplied p_mfa_verified / p_guild_member, which are computed client-side in '
+  'src/lib/auth-helpers.ts from Discord OAuth responses (mfa_enabled flag + '
+  '/users/@me/guilds). Server-side re-validation of Discord MFA/guild state is an '
+  'accepted residual (pre-existing design, no live users) — closing the direct-PostgREST '
+  'escalation path is the scope of DBHY-05.';
+
+
+-- Make the EXECUTE grant explicit so the trusted boundary is auditable.
+-- Prior migrations did not set an explicit grant; the RPC relied on the
+-- Postgres default PUBLIC EXECUTE. Anon clients can no longer call this RPC.
+REVOKE EXECUTE ON FUNCTION public.update_profile_after_auth(BOOLEAN, TEXT, TEXT, BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_profile_after_auth(BOOLEAN, TEXT, TEXT, BOOLEAN) TO authenticated;

--- a/supabase/migrations/00000000000015_trusted_profile_update_guc.sql
+++ b/supabase/migrations/00000000000015_trusted_profile_update_guc.sql
@@ -78,6 +78,13 @@ BEGIN
   IF NEW.created_at != OLD.created_at THEN
     RAISE EXCEPTION 'Cannot change created_at';
   END IF;
+  -- is_admin is NEVER set by any self-update RPC, so it stays unconditional
+  -- alongside the other immutable columns rather than inside the GUC-gated
+  -- branch. This keeps the trusted-context bypass scoped to the columns
+  -- update_profile_after_auth actually writes (mfa_verified, guild_member).
+  IF NEW.is_admin != OLD.is_admin THEN
+    RAISE EXCEPTION 'Cannot change is_admin via client';
+  END IF;
 
   -- Check trusted-context flag set by update_profile_after_auth.
   -- missing_ok=true (second arg) returns '' when the GUC is absent
@@ -85,9 +92,6 @@ BEGIN
   -- null-safe; gate fires (protected checks run) when the flag is absent.
   IF pg_catalog.current_setting('app.trusted_profile_update', true) IS DISTINCT FROM 'on' THEN
     -- Direct client update — enforce protected column restrictions
-    IF NEW.is_admin != OLD.is_admin THEN
-      RAISE EXCEPTION 'Cannot change is_admin via client';
-    END IF;
     IF NEW.mfa_verified != OLD.mfa_verified THEN
       RAISE EXCEPTION 'Cannot change mfa_verified via client -- use update_profile_after_auth RPC';
     END IF;
@@ -103,11 +107,12 @@ $$;
 
 
 COMMENT ON FUNCTION public.profile_self_update_allowed IS
-  'Guards profile self-update: blocks id/discord_id/created_at unconditionally; '
-  'blocks is_admin/mfa_verified/guild_member when app.trusted_profile_update GUC is absent '
+  'Guards profile self-update: blocks id/discord_id/created_at/is_admin unconditionally; '
+  'blocks mfa_verified/guild_member when app.trusted_profile_update GUC is absent '
   '(direct client write). update_profile_after_auth sets the GUC (transaction-local, '
-  'is_local=true) before its UPDATE so the protected-column checks are skipped on the '
-  'RPC path. IS DISTINCT FROM ''on'' is used for null-safe gate evaluation.';
+  'is_local=true) before its UPDATE so the GUC-gated checks are skipped on the '
+  'RPC path. is_admin stays unconditional because no self-update RPC writes it. '
+  'IS DISTINCT FROM ''on'' is used for null-safe gate evaluation.';
 
 COMMENT ON FUNCTION public.update_profile_after_auth(BOOLEAN, TEXT, TEXT, BOOLEAN) IS
   'SECURITY DEFINER RPC: sets the transaction-local GUC app.trusted_profile_update '


### PR DESCRIPTION
## Summary

**Phase 19: DB Migration + A11y Restore** &nbsp;·&nbsp; Milestone v1.4 (Final Closeout)
**Status:** Verified ✓ · Threat-secure ✓ · Nyquist-compliant ✓ · UAT-passed ✓

Closes two v1 carry-forward items:

- **DBHY-05** — fixes a privilege-escalation path in the `profile_self_update_allowed` trigger. The previous `current_user = session_user` gate is *permanently false* inside a `SECURITY DEFINER` trigger, so direct client `UPDATE`s to `is_admin` / `mfa_verified` / `guild_member` were silently accepted. Migration 15 replaces it with a transaction-local GUC trusted-context flag (`app.trusted_profile_update`) set only by `update_profile_after_auth`.
- **UIDN-06** — restores two real `<h2>` section headings in the admin dashboard (`AdminsList` / `CategoriesList`) that Phase 17 had demoted to `<div role="heading" aria-level={2}>` ARIA workarounds, by making `CardTitle` polymorphic via `asChild` / `Slot.Root`.

> Planning artifacts (`.planning/`) are intentionally excluded from this PR for a clean review diff; they live on `main` per the project's planning convention.

## Changes

### Migration 15 — GUC-based trusted-context gate (DBHY-05)
`supabase/migrations/00000000000015_trusted_profile_update_guc.sql`
- `update_profile_after_auth` sets `pg_catalog.set_config('app.trusted_profile_update', 'on', true)` (`is_local=true`, transaction-scoped, PgBouncer-safe) before its `UPDATE`.
- `profile_self_update_allowed` gates protected columns behind `pg_catalog.current_setting(..., true) IS DISTINCT FROM 'on'` (null-safe). `is_admin` is **unconditional** (defense-in-depth — no self-update RPC ever writes it); `mfa_verified` / `guild_member` are gated.
- Both functions: `SET search_path = ''` with `pg_catalog`-qualified built-ins; `CREATE OR REPLACE` (no `DROP`, preserves trigger OID binding); explicit `REVOKE EXECUTE FROM PUBLIC` + `GRANT EXECUTE TO authenticated`.

### Integration test — DBHY-05 regression proof
`e2e/integration/profile-trigger-gate.test.ts`
- 6 cases: direct-UPDATE rejections for `mfa_verified`/`is_admin`/`guild_member`, allowed-column sanity, the ordered RPC GUC-bypass proof (flip→call→read-back), and a GUC-leak guard.

### A11y heading restore (UIDN-06)
`src/components/ui/card.tsx`, `src/components/admin/AdminsList.tsx`, `src/components/admin/CategoriesList.tsx`, `src/__tests__/admin/{admins,categories}-tab.test.tsx`
- `CardTitle` gains `asChild` polymorphism (`Slot.Root`), same pattern as `button.tsx`/`badge.tsx`.
- Admin section titles now render native `<h2>`; `role="heading"`/`aria-level` removed; unit tests assert `getByRole('heading', { level: 2 })`.
- Section-title top spacing restored (`CardHeader` `pt-4 pb-3`) without un-compacting list rows.

## Requirements Addressed

- **DBHY-05** — `profile_self_update_allowed` privilege-escalation gate fixed (session-GUC trusted-context flag).
- **UIDN-06** — two `<h2>` semantic admin headings restored.

## Verification

- [x] Build: clean (0 TypeScript errors)
- [x] Unit suite: **403/403** pass (incl. UIDN-06 heading-level assertions)
- [x] Integration suite: **32/32** pass against the live local stack post-migration (`profile-trigger-gate` 6/6; `vote-counts-rls` 13/13)
- [x] Supabase advisor lint: clean — no `0011_function_search_path_mutable` WARN
- [x] `@smoke` Playwright: **6/6** pass (submit-vote round-trips unaffected)
- [x] Code review (deep): **clean** — 0 critical / 0 warning (3 warnings found + fixed; 4 info, 1 actionable fixed)
- [x] Security audit: **secured** — 14/14 threats closed, 0 open
- [x] UAT: 3/3 passed (1 cosmetic spacing item surfaced and fixed inline)

**Deferred (not in scope):** the production `--linked` migration deploy ships in normal v1.4 milestone order (no live users yet).

## Key Decisions

- Transaction-local GUC (`is_local=true`) over session-local — auto-clears on commit, safe under PgBouncer transaction pooling.
- `IS DISTINCT FROM 'on'` (null-safe) over `!= 'on'` — matches in-repo precedent.
- `is_admin` kept unconditional outside the GUC bypass (defense-in-depth) — the trusted RPC never writes it.
- **Accepted residual (T-19-07):** `update_profile_after_auth` still trusts caller-supplied `p_mfa_verified` / `p_guild_member` (computed client-side from Discord OAuth, not re-derived server-side). Pre-existing since migration 02, not widened here; documented in the function `COMMENT` and tracked for a future server-side-revalidation auth refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Card component now supports flexible child rendering with `asChild` prop for improved composition.

* **Bug Fixes**
  * Enhanced security on profile self-updates with gated authentication to prevent unauthorized modification of sensitive fields.

* **Style**
  * Improved layout and spacing in admin panel card headers using native heading elements for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->