### PR TITLE
fix: admin delete at any stage + close results-hidden first-paint flash

### DIFF
--- a/src/__tests__/admin/suggestion-crud-edge.test.ts
+++ b/src/__tests__/admin/suggestion-crud-edge.test.ts
@@ -145,7 +145,7 @@ describe('suggestion CRUD Edge Functions source analysis', () => {
     })
   })
 
-  describe('delete-poll server-side delete lock', () => {
+  describe('delete-poll always-allowed admin delete', () => {
     const src = efSrc('delete-poll')
 
     it('exists and is non-empty', () => {
@@ -157,25 +157,16 @@ describe('suggestion CRUD Edge Functions source analysis', () => {
       expect(src).toMatch(/requireAdmin\s*\(/)
     })
 
-    it('contains EXISTS guard on votes table', () => {
-      expect(src).toMatch(/from\(\s*['"]votes['"]\s*\)/)
-      expect(src).toMatch(/poll_id/)
-    })
-
-    it('returns 409 on guard hit', () => {
-      expect(src).toMatch(/409/)
-    })
-
     it('deletes from polls table', () => {
       expect(src).toMatch(/from\(\s*['"]polls['"]\s*\)\s*\.\s*delete/)
     })
 
-    it('vote guard appears BEFORE the delete call', () => {
-      const votesIdx = src.search(/from\(\s*['"]votes['"]\s*\)/)
-      const deleteIdx = src.search(/from\(\s*['"]polls['"]\s*\)\s*\.\s*delete/)
-      expect(votesIdx).toBeGreaterThan(-1)
-      expect(deleteIdx).toBeGreaterThan(-1)
-      expect(votesIdx).toBeLessThan(deleteIdx)
+    it('no longer references the votes table', () => {
+      expect(src).not.toMatch(/from\(\s*['"]votes['"]\s*\)/)
+    })
+
+    it('no longer returns the votes-guard 409 text', () => {
+      expect(src).not.toMatch(/responses already received/)
     })
   })
 

--- a/src/__tests__/admin/suggestion-crud-edge.test.ts
+++ b/src/__tests__/admin/suggestion-crud-edge.test.ts
@@ -168,6 +168,13 @@ describe('suggestion CRUD Edge Functions source analysis', () => {
     it('no longer returns the votes-guard 409 text', () => {
       expect(src).not.toMatch(/responses already received/)
     })
+
+    it('no longer emits a 409 status anywhere', () => {
+      // Pin the 409-branch removal directly, not just its copy: the function
+      // returns statuses positionally (json(body, 409, cors)), so assert the
+      // status code itself is gone rather than a `status: 409` literal.
+      expect(src).not.toMatch(/\b409\b/)
+    })
   })
 
   describe('set-resolution', () => {

--- a/src/__tests__/suggestions/results-visibility.test.tsx
+++ b/src/__tests__/suggestions/results-visibility.test.tsx
@@ -7,6 +7,15 @@ vi.mock('lucide-react', () => ({
   Loader2: ({ className }: { className?: string }) => (
     <span data-testid="loader-spinner" className={className} />
   ),
+  Search: () => <span data-testid="search-icon" />,
+  X: () => <span data-testid="x-icon" />,
+  ChevronDown: () => <span data-testid="chevron-icon" />,
+  Pin: () => <span data-testid="pin-icon" />,
+  Clock: () => <span data-testid="clock-icon" />,
+  SearchX: () => <span data-testid="search-x-icon" />,
+  Inbox: () => <span data-testid="inbox-icon" />,
+  Archive: () => <span data-testid="archive-icon" />,
+  EyeOff: () => <span data-testid="eye-off-icon" />,
 }))
 
 // Mock @/components/ui/button
@@ -34,10 +43,58 @@ vi.mock('@/lib/format', () => ({
     if (total === 0) return 0
     return Math.round((count / total) * 100)
   },
+  formatTimeRemaining: () => '7 days left',
+}))
+
+// --- Integration harness for the first-paint fail-closed gate ---
+// SuggestionList renders SuggestionCard for every voted poll. We drive
+// useVoteCounts directly so we can simulate the unknown window (an empty
+// resultsHidden map) while voteCounts is already populated — the exact
+// condition under which a leak WOULD surface if the gate were fail-open.
+const mockUseSuggestions = vi.fn()
+vi.mock('@/hooks/useSuggestions', () => ({
+  useSuggestions: () => mockUseSuggestions(),
+}))
+
+const mockUseCategories = vi.fn()
+vi.mock('@/hooks/useCategories', () => ({
+  useCategories: () => mockUseCategories(),
+}))
+
+const mockUseVoteCounts = vi.fn()
+vi.mock('@/hooks/useVoteCounts', () => ({
+  useVoteCounts: () => mockUseVoteCounts(),
+}))
+
+vi.mock('@/hooks/useVoteSubmit', () => ({
+  useVoteSubmit: () => ({
+    submitVote: vi.fn(),
+    submittingPollId: null,
+    submittingChoiceId: null,
+  }),
+}))
+
+vi.mock('@/hooks/useDebounce', () => ({
+  useDebounce: (value: unknown) => value,
+}))
+
+vi.mock('@/hooks/usePolling', () => ({
+  usePolling: vi.fn(),
+}))
+
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
 
 import { ChoiceButtons } from '@/components/suggestions/ChoiceButtons'
 import { ResultBars } from '@/components/suggestions/ResultBars'
+import { SuggestionList } from '@/components/suggestions/SuggestionList'
 
 const mockChoices = [
   { id: 'c1', label: 'Yes, remove it', sort_order: 1, poll_id: 'p1', created_at: '' },
@@ -227,5 +284,87 @@ describe('Results visibility', () => {
 
     // Total responses (singular)
     expect(screen.getByText('0 total responses')).toBeInTheDocument()
+  })
+})
+
+// First-paint contract: a voted poll whose results_hidden flag has not yet
+// resolved (no map entry — the unknown window) must NOT leak vote counts.
+// The gate must fail closed: render the censored placeholder, never ResultBars.
+describe('Results visibility — first-paint fail-closed gate (RSLT-flash)', () => {
+  const votedSuggestion = {
+    id: 'poll-1',
+    title: 'Remove MiG-29',
+    description: 'A test description',
+    status: 'active' as const,
+    is_pinned: false,
+    category_id: 'cat-1',
+    categories: { id: 'cat-1', name: 'Rules', slug: 'rules', sort_order: 1, created_at: '' },
+    choices: [
+      { id: 'c1', label: 'Yes, remove it', sort_order: 1, poll_id: 'poll-1', created_at: '' },
+      { id: 'c2', label: 'No, keep it', sort_order: 2, poll_id: 'poll-1', created_at: '' },
+    ],
+    closes_at: new Date(Date.now() + 86400000).toISOString(),
+    closed_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    created_by: 'user-1',
+    image_url: null,
+    resolution: null,
+  }
+
+  // Counts are already loaded — so a leak WOULD be visible if the gate were open.
+  const populatedVoteCounts = new Map([
+    ['poll-1', new Map<string, number>([['c1', 15], ['c2', 5]])],
+  ])
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSuggestions.mockReturnValue({
+      suggestions: [votedSuggestion],
+      // The current user HAS voted (c1) — voted-poll branch is in play.
+      userVotes: new Map([['poll-1', 'c1']]),
+      loading: false,
+      error: null,
+      addOptimisticVote: vi.fn(),
+    })
+    mockUseCategories.mockReturnValue({
+      categories: [{ id: 'cat-1', name: 'Rules', slug: 'rules', sort_order: 1, created_at: '' }],
+      loading: false,
+    })
+  })
+
+  it('does not render vote counts before results_hidden resolves (unknown window => hidden)', () => {
+    // resultsHidden is EMPTY (map-miss = unknown / not-yet-fetched) while
+    // voteCounts is already populated.
+    mockUseVoteCounts.mockReturnValue({
+      voteCounts: populatedVoteCounts,
+      resultsHidden: new Map<string, boolean>(),
+      refetchVoteCounts: vi.fn(),
+    })
+
+    render(<SuggestionList status="active" />)
+
+    // No counts leaked: ResultBars (meter role + percentages) must NOT render.
+    expect(screen.queryByRole('meter')).not.toBeInTheDocument()
+    expect(screen.queryByText('75%')).not.toBeInTheDocument()
+    // The censored placeholder shows instead.
+    expect(screen.getByTestId('results-hidden-alert-poll-1')).toBeInTheDocument()
+    expect(screen.getByText('Results temporarily hidden by admin')).toBeInTheDocument()
+  })
+
+  it('renders ResultBars once results_hidden resolves to false (no regression)', () => {
+    mockUseVoteCounts.mockReturnValue({
+      voteCounts: populatedVoteCounts,
+      resultsHidden: new Map<string, boolean>([['poll-1', false]]),
+      refetchVoteCounts: vi.fn(),
+    })
+
+    render(<SuggestionList status="active" />)
+
+    // Flag resolved to visible => counts render.
+    expect(screen.getAllByRole('meter')).toHaveLength(2)
+    expect(screen.getByText('75%')).toBeInTheDocument()
+    expect(screen.getByText('25%')).toBeInTheDocument()
+    expect(screen.queryByTestId('results-hidden-alert-poll-1')).not.toBeInTheDocument()
   })
 })

--- a/src/components/admin/DeleteSuggestionDialog.tsx
+++ b/src/components/admin/DeleteSuggestionDialog.tsx
@@ -33,8 +33,8 @@ export function DeleteSuggestionDialog({ open, onOpenChange, pollId, onDeleted }
         <DialogHeader>
           <DialogTitle>Delete this suggestion?</DialogTitle>
           <DialogDescription>
-            This permanently removes the suggestion and all of its choices. This cannot be
-            undone. Suggestions with responses cannot be deleted.
+            This permanently removes the suggestion, all of its choices, and every
+            response already received. This cannot be undone.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/src/components/admin/SuggestionKebabMenu.tsx
+++ b/src/components/admin/SuggestionKebabMenu.tsx
@@ -43,7 +43,6 @@ export function SuggestionKebabMenu({
 
   const hasVotes = voteCount > 0
   const editDisabled = hasVotes
-  const deleteDisabled = hasVotes
   const closeItemDisabled = status !== 'active'
   const resolutionItemDisabled = status !== 'closed'
 
@@ -123,22 +122,10 @@ export function SuggestionKebabMenu({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            disabled={deleteDisabled}
-            aria-describedby={deleteDisabled ? `kebab-delete-reason-${pollId}` : undefined}
-            className="text-destructive focus:text-destructive flex-col items-start gap-0.5"
-            onClick={() => !deleteDisabled && setDeleteOpen(true)}
+            className="text-destructive focus:text-destructive"
+            onClick={() => setDeleteOpen(true)}
           >
-            <span className="flex items-center">
-              <Trash2 className="h-4 w-4 mr-2" /> Delete
-            </span>
-            {deleteDisabled && (
-              <span
-                id={`kebab-delete-reason-${pollId}`}
-                className="text-xs text-muted-foreground pl-6"
-              >
-                Cannot delete after responses received.
-              </span>
-            )}
+            <Trash2 className="h-4 w-4 mr-2" /> Delete
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/suggestions/SuggestionList.tsx
+++ b/src/components/suggestions/SuggestionList.tsx
@@ -37,8 +37,11 @@ export function SuggestionList({ status, focusId }: SuggestionListProps) {
   // Polling enabled only for active suggestions. Closed suggestions fetch once on mount.
   const enablePolling = status === 'active'
   // results_hidden is polled at the useVoteCounts cadence so the voter
-  // UI auto-updates within ~8s of an admin flip. Map-miss defaults to
-  // visible — RLS enforces no-leak independently at the DB layer.
+  // UI auto-updates within ~8s of an admin flip. A map-miss is the
+  // not-yet-resolved (unknown) window before the first fetch lands, so the
+  // consumer below defaults it to HIDDEN — fail-closed, so a poll an admin
+  // may have hidden can never leak counts on first paint. RLS enforces the
+  // same no-leak guarantee independently at the DB layer.
   const { voteCounts, resultsHidden } = useVoteCounts(votedPollIds, enablePolling)
   const { submitVote, submittingPollId, submittingChoiceId } = useVoteSubmit(addOptimisticVote)
 
@@ -150,7 +153,7 @@ export function SuggestionList({ status, focusId }: SuggestionListProps) {
                     suggestion={suggestion}
                     categoryIndex={categoryIndex >= 0 ? categoryIndex : 0}
                     userChoiceId={userVotes.get(suggestion.id)}
-                    resultsHidden={resultsHidden.get(suggestion.id) ?? false}
+                    resultsHidden={resultsHidden.get(suggestion.id) ?? true}
                     onVote={submitVote}
                     voteCounts={voteCounts.get(suggestion.id)}
                     submittingPollId={submittingPollId}

--- a/src/hooks/useVoteCounts.ts
+++ b/src/hooks/useVoteCounts.ts
@@ -111,9 +111,11 @@ export function useVoteCounts(
     } else if (hiddenRows) {
       const hMap = new Map<string, boolean>()
       for (const row of hiddenRows) {
-        // Defensive Boolean coerce: view-level nullability may differ from the
-        // underlying NOT NULL column; default to visible (false) on any null.
-        hMap.set(row.id, Boolean(row.results_hidden))
+        // View-level nullability may differ from the underlying NOT NULL
+        // column; fail closed unless the view explicitly says visible (false),
+        // so a null never becomes a present "visible" entry that bypasses the
+        // map-miss fallback.
+        hMap.set(row.id, row.results_hidden !== false)
       }
       setResultsHidden(hMap)
     }

--- a/src/hooks/useVoteCounts.ts
+++ b/src/hooks/useVoteCounts.ts
@@ -18,6 +18,14 @@ export function useVoteCounts(
   // voter UI auto-updates within ~8s of an admin flip. Query targets the
   // polls_effective view (never the base polls table) to preserve the
   // single-read-path invariant enforced by polls-effective-invariant.test.ts.
+  //
+  // Consumer contract: an ABSENT entry means "not yet resolved" (the unknown
+  // window before the first fetch lands), NOT "visible". Consumers MUST treat
+  // a map-miss as hidden (fail-closed) so first paint can never leak counts an
+  // admin may have hidden. The map stays implicit-tri-state (present-true /
+  // present-false / absent-unknown) rather than carrying an explicit 'unknown'
+  // value, since every voted poll id is queried each fetch and gets an entry on
+  // success — a persistent miss only exists in the pre-first-resolution window.
   const [resultsHidden, setResultsHidden] = useState<Map<string, boolean>>(new Map())
 
   // Stabilize dependency: serialize to a sorted, pipe-joined key so the SET

--- a/supabase/functions/delete-poll/index.ts
+++ b/supabase/functions/delete-poll/index.ts
@@ -1,8 +1,9 @@
 // supabase/functions/delete-poll/index.ts
 //
-// Admin-gated hard delete (D-18). Server-side delete lock: rejects 409 if any
-// votes exist for the poll (uses EXISTS on the votes table — vote_counts is a
-// CACHE and must NEVER be the source of truth for security decisions).
+// Admin-gated hard delete, always allowed at any lifecycle stage. An
+// authenticated admin may delete a suggestion before votes, while voting is
+// active, or after close. The polls DELETE cascades to votes, vote_counts, and
+// choices via ON DELETE CASCADE FKs, so responses are removed with no orphans.
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.101.1'
 import { getCorsHeaders } from '../_shared/cors.ts'
@@ -58,21 +59,6 @@ Deno.serve(async (req) => {
     }
     if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(poll_id)) {
       return json({ error: 'Invalid poll_id' }, 400, corsHeaders)
-    }
-
-    // EXISTS guard: refuse to delete if any votes already exist (D-18).
-    const { data: voteRow, error: voteCheckError } = await supabaseAdmin
-      .from('votes')
-      .select('id')
-      .eq('poll_id', poll_id)
-      .limit(1)
-      .maybeSingle()
-    if (voteCheckError) {
-      console.error('delete-poll vote pre-check failed:', voteCheckError)
-      return json({ error: 'Internal error' }, 500, corsHeaders)
-    }
-    if (voteRow) {
-      return json({ error: 'Cannot delete: responses already received' }, 409, corsHeaders)
     }
 
     // Best-effort capture of pre-DELETE snapshot for the audit `before` payload.


### PR DESCRIPTION
## Summary

Two pieces of user feedback (from Tim), handled as inline fixes — no milestone.

### 1. Admin delete at any lifecycle stage (reverses the D-18 delete lock)
Admins can now delete an entire suggestion regardless of vote state — before votes, in progress, or after close. Previously `delete-poll` returned `409` if any responses existed.

- Removed the votes-`EXISTS` guard in `supabase/functions/delete-poll/index.ts`; `requireAdmin`, UUID validation, the `poll_deleted` audit write, and 404-on-missing are unchanged.
- No migration needed — `votes.poll_id`, `vote_counts.poll_id`, `choices.poll_id` already have `ON DELETE CASCADE`, so deletes clean up cleanly with no orphans.
- Un-gated the Delete control in `SuggestionKebabMenu.tsx` (Edit lock left intact) and strengthened the destructive confirm copy in `DeleteSuggestionDialog.tsx`.
- **Integrity trade-off:** this intentionally walks back the "no delete once responses exist" stance for maximum admin flexibility. Whole-suggestion deletion only — no individual-vote deletion. (Decision record kept on `main` in `.planning/`, out of this code-only PR.)

### 2. Close the results-hidden "flash"
A voted poll with `results_hidden=true` briefly leaked real vote counts (~1–2s) on first load before the hidden flag resolved.

- Root cause: `SuggestionList.tsx` defaulted the unresolved (not-yet-fetched) hidden flag to `?? false` — fail-**open**, indistinguishable from "fetched, not hidden".
- Fix: flip to `?? true` (fail-**closed**). The unknown first-paint window now renders the existing "hidden by admin" placeholder; worst case is a brief censored state, never leaked numbers. No SSR / no architecture change (locked static Vite SPA).
- Covers both `/topics` and `/archive` (single call site). `useVoteCounts.ts` documents the consumer contract.

## Testing
- `suggestion-crud-edge.test.ts` rewritten to assert always-allowed deletion (negative assertions on the old votes/`409` path).
- `results-visibility.test.tsx` adds a first-paint fail-closed regression (RED→GREEN confirmed) + a non-regression test for the visible case.
- Impacted suites: **46/46 pass**; `eslint --max-warnings 0` clean; `tsc -b` clean. CodeRabbit review: no source findings.

## Deploy note
The Edge Function change is not live until `supabase functions deploy delete-poll`. Frontend ships via Netlify on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin deletion is now consistently allowed for polls regardless of voting/closure state (no longer blocked by existing responses).
  * Poll results visibility now fail-closed: results stay hidden until `resultsHidden` is resolved, avoiding any initial-load count leakage.
  * Suggestions can always be deleted from the admin menu (no longer disabled when votes exist).

* **Documentation**
  * Clarified the `resultsHidden` contract and fail-closed behavior for consumers.

* **UI Updates**
  * Updated delete confirmation text to reflect permanent removal.

* **Tests**
  * Strengthened coverage for results-hidden placeholder rendering and updated poll-delete policy assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->